### PR TITLE
tzone argument for sendQuery (MariaDB)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dbtools
 Type: Package
 Title: Tools for Querying Databases
-Version: 0.5.2
+Version: 0.5.3
 Authors@R: c(
     person("Jonathan", "Bob", , "jonathan.bob@inwt-statistics.de", c("aut")),
     person("Sebastian", "Warnholz", , "sebastian.warnholz@inwt-statistics.de", role = c("aut", "cre")))


### PR DESCRIPTION
https://github.com/r-dbi/RMariaDB/issues/116: RMariaDB always sets the session timezone to UTC

Probleme entstehen, wenn wir einen Timestamp als Character in die Datenbank schreiben und dann wieder auslesen. Wenn wir eigentlich in der CET Zeitzone arbeiten und den Timestamp dann auch so rausschreiben bekommen wir beim Auslesen einen Timestamp mit einer Stunde Verschiebung zurück, da MariaDB annimmt, dass der Timestamp UTC Zeitzone hat.

Mit diesem Fix gibt es die Möglichkeit bei der sendQuery einen `tz` Parameter zu übergeben, der angibt, welche Zeitzone die Timestamps, die man abfragt, eigentlich hat.
